### PR TITLE
ACC-1169 main branch name change chores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
-  filters_ignore_master: &filters_ignore_master
+  filters_ignore_main: &filters_ignore_main
     branches:
-      ignore: master
+      ignore: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -154,7 +154,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ a metrics [decorator](https://github.com/Financial-Times/n-express-enhancer) to 
 ![node version](https://img.shields.io/node/v/@financial-times/n-auto-metrics.svg)
 
 [![CircleCI](https://circleci.com/gh/Financial-Times/n-auto-metrics.svg?style=shield)](https://circleci.com/gh/Financial-Times/n-auto-metrics)
-[![Coverage Status](https://coveralls.io/repos/github/Financial-Times/n-auto-metrics/badge.svg?branch=master)](https://coveralls.io/github/Financial-Times/n-auto-metrics?branch=master) 
+[![Coverage Status](https://coveralls.io/repos/github/Financial-Times/n-auto-metrics/badge.svg?branch=main)](https://coveralls.io/github/Financial-Times/n-auto-metrics?branch=main) 
 [![Known Vulnerabilities](https://snyk.io/test/github/Financial-Times/n-auto-metrics/badge.svg)](https://snyk.io/test/github/Financial-Times/n-auto-metrics)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Financial-Times/n-auto-metrics/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Financial-Times/n-auto-metrics/?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Financial-Times/n-auto-metrics/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/Financial-Times/n-auto-metrics/?branch=main)
 [![Dependencies](https://david-dm.org/Financial-Times/n-auto-metrics.svg)](https://david-dm.org/Financial-Times/n-auto-metrics)
 [![devDependencies](https://david-dm.org/Financial-Times/n-auto-metrics/dev-status.svg)](https://david-dm.org/Financial-Times/n-auto-metrics?type=dev)
 
@@ -103,7 +103,7 @@ for upstream service reliability:
 
 ### the Meta
 
-check the common meta used by [n-auto-logger](https://github.com/Financial-Times/n-auto-logger/blob/master/README.md#the-meta)
+check the common meta used by [n-auto-logger](https://github.com/Financial-Times/n-auto-logger/blob/main/README.md#the-meta)
 
 `meta.segment` would be picked up in the metrics to help measure business metrics with user segment breakdown.
 

--- a/package.json
+++ b/package.json
@@ -10,16 +10,13 @@
     "test": "jest",
     "cover": "jest --coverage",
     "prepublish": "make build",
-    "precommit": "node_modules/.bin/secret-squirrel",
-    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-    "prepush": "make lint unit-test && make verify -j3",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "dependencies": {
     "@financial-times/n-express-enhancer": "^1.8.1"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^3.6.0",
+    "@financial-times/n-gage": "^8.2.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.6",
@@ -42,5 +39,12 @@
   },
   "engines": {
     "node": ">=6.1.0"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
+      "pre-commit": "node_modules/.bin/secret-squirrel",
+      "pre-push": "make lint unit-test && make verify -j3"
+    }
   }
 }


### PR DESCRIPTION
**Description**
Following the branch name change, this PR handles associated chores as per https://github.com/Financial-Times/next/wiki/Migrating-apps-to-use-main-branch-(instead-of-master)
- upgrades n-gage
- updates CI yaml to use the new name
- closes #12 

**Ticket**
https://financialtimes.atlassian.net/browse/ACC-1169

**We're bumping how many n-gage versions?!**
TOO MANY. But I think none of those changes affect this repo.
v8.0.0 - the package-lock.json change is opt in https://github.com/Financial-Times/n-gage/releases/tag/v8.0.0
v7.0.0 - is an upgrade to Node v12 https://github.com/Financial-Times/n-gage/releases/tag/v7.0.0
v6.0.0 - something to do with asset-hashes.json, action only needed if this file is present in the project
v5.0.0 - updates Husky format. Staging smoke tests now run on https
v4.0.0 - removes all n-ui related code