### PR TITLE
Make node version explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "supertest": "^3.1.0"
   },
   "engines": {
-    "node": ">=6.1.0"
+    "node": "12.x"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Marcelo pointed out that what we had, although it did say "the version should be at least this", at this point it left the gap of several versions and given that FT has standardised on v12 for the time being, we probably should make this explicit. 

This PR makes the node engine version explicit to `12.x`.